### PR TITLE
Update default cluster external access method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ kubespray_nfs_provisioner:
 #  chart_repo_url: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner"
 #  chart_ref: "nfs-subdir-external-provisioner"
 #  release_name: "nfs-provisioner"
-#  extraValues:
+#  extraValues: |
 #    image:
 #       tag:
 
@@ -133,7 +133,9 @@ kubespray_acme_cluster_issuer:
 cert_manager:
   version: v1.7.1
 
-## metallb config (When using metallb provide uncomment the configurations below)
+## Begin metallb config (When using metallb uncomment the configurations below)
+
+## metallb config 
 
 # external ip for ingress nginx controller with port it maps to usually 80/443
 # any another service to be accessed external on a custom port can be added here, provided it has an LoadBalancer service type.

--- a/README.md
+++ b/README.md
@@ -113,12 +113,19 @@ kubespray_nfs_provisioner:
 #  chart_repo_url: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner"
 #  chart_ref: "nfs-subdir-external-provisioner"
 #  release_name: "nfs-provisioner"
-kubespray_ingress_nginx_controller:
+#  extraValues:
+#    image:
+#       tag:
+
+kubespray_ingress_nginx:
   chart_version: ""
 #  namespace: "ingress-nginx"
 #  chart_repo_url: "https://kubernetes.github.io/ingress-nginx"
 #  chart_ref: "ingress-nginx"
 #  release_name: "ingress-nginx"
+#  values:
+#    controller:
+#      kind:
 
 kubespray_acme_cluster_issuer:
   email: "your-email@me"
@@ -126,18 +133,39 @@ kubespray_acme_cluster_issuer:
 cert_manager:
   version: v1.7.1
 
-nfs:
-  server: "{{ hostvars['<node>']['ip'] }}"
+## metallb config (When using metallb provide uncomment the configurations below)
 
 # external ip for ingress nginx controller with port it maps to usually 80/443
 # any another service to be accessed external on a custom port can be added here, provided it has an LoadBalancer service type.
 # it matches the ip used for metallb 'metallb_ip_range' config mentioned above.
-port_ip_map:
-  - 192.168.100.2:80
-  - 192.168.100.2:443
+#port_ip_map:
+#  - 192.168.100.2:80
+#  - 192.168.100.2:443
 
-# default tunl0, if its same as the default one can omit the below variable.
-kubespray_k8s_interface: tunl0
+# needed for metallb to work
+#kube_proxy_strict_arp: true
+
+#metallb_enabled: true
+#metallb_speaker_enabled: true
+#metallb_protocol: "layer2"
+#metallb_port: "7472"
+#
+## metallb_controller_tolerations is needed to ensure the least downtime if the node holding the metallb controller goes down.
+#metallb_controller_tolerations:
+#  - key: "node.kubernetes.io/unreachable"
+#    operator: "Exists"
+#    effect: "NoExecute"
+#    tolerationSeconds: 2
+#  - key: "node.kubernetes.io/not-ready"
+#    operator: "Exists"
+#    effect: "NoExecute"
+
+# default tunl0 for calico_network_backend IPIP mode and vxlan.calico for vxlan, if its same as the default one can omit the below variable. This is needed for metallb setup.
+#kubespray_k8s_interface: tunl0
+## end metallb config
+
+nfs:
+  server: "{{ hostvars['<node>']['ip'] }}"
 ```
 
 ### Run the k8s post cluster setup play

--- a/playbooks/iptables-config.yml
+++ b/playbooks/iptables-config.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Add Iptables Configuration"
+- name: "Add Iptables Configuration For Metallb"
   hosts: k8s_cluster
   become: yes
   tasks:

--- a/playbooks/kubespray.yml
+++ b/playbooks/kubespray.yml
@@ -66,6 +66,8 @@
   tags:
     - post-cluster-setup
     - iptables-config
+  when:
+    - metallb_enabled | bool
 
 - name: "Upgrade Cluster"
   import_playbook: ../external/kubespray/upgrade-cluster.yml

--- a/playbooks/post-cluster-setup.yml
+++ b/playbooks/post-cluster-setup.yml
@@ -77,6 +77,7 @@
             chart_ref: "{{ ingress_nginx.chart_ref }}"
             chart_version: "{{ ingress_nginx.chart_version }}"
             state: present
+            values: "{{ ingress_nginx.chart_values | default(omit) }}"
           tags:
             - helm-install-ingress-nginx
 

--- a/templates/nfs-provisioner-values.yml.j2
+++ b/templates/nfs-provisioner-values.yml.j2
@@ -4,3 +4,5 @@ nfs:
   path: {{ nfs_provisioner.path }}
 storageClass:
   defaultClass: {{ nfs_provisioner.is_storage_class_default }}
+
+{{ nfs_provisioner.extra_chart_values }}

--- a/vars/on-prem.yml
+++ b/vars/on-prem.yml
@@ -30,7 +30,7 @@ nfs_provisioner:
 
 ingress_nginx:
   namespace: "{{ kubespray_ingress_nginx.namespace | default('ingress-nginx') }}"
-  chart_version: "{{ kubespray_ingress_nginx.chart_version | default(kubespray_ingress_nginx_controller.chart_version) }}"
+  chart_version: "{{ kubespray_ingress_nginx.chart_version }}"
   chart_repo_url: "{{ kubespray_ingress_nginx.chart_repo_url | default('https://kubernetes.github.io/ingress-nginx') }}"
   chart_ref: "{{ kubespray_ingress_nginx.chart_ref | default('ingress-nginx') }}"
   release_name: "{{ kubespray_ingress_nginx.release_name | default('ingress-nginx') }}"

--- a/vars/on-prem.yml
+++ b/vars/on-prem.yml
@@ -10,28 +10,6 @@ helm_enabled: true
 etcd_deployment_type: host
 container_manager: containerd
 
-## metallb config
-
-# needed for metallb to work
-kube_proxy_strict_arp: true
-
-metallb_enabled: true
-metallb_speaker_enabled: true
-metallb_protocol: "layer2"
-metallb_port: "7472"
-
-# metallb_controller_tolerations is needed to ensure the least downtime if the node holding the metallb controller goes down.
-metallb_controller_tolerations:
-  - key: "node.kubernetes.io/unreachable"
-    operator: "Exists"
-    effect: "NoExecute"
-    tolerationSeconds: 2
-  - key: "node.kubernetes.io/not-ready"
-    operator: "Exists"
-    effect: "NoExecute"
-
-## end metallb config
-
 #nfs:
 #  server: "{{ hostvars['nodeX]['ip'] }}"
 
@@ -48,13 +26,15 @@ nfs_provisioner:
   chart_repo_url: "{{ kubespray_nfs_provisioner.chart_repo_url | default('https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner') }}"
   chart_ref: "{{ kubespray_nfs_provisioner.chart_ref | default('nfs-subdir-external-provisioner') }}"
   release_name: "{{ kubespray_nfs_provisioner.release_name | default('nfs-provisioner') }}"
+  extra_chart_values: "{{ kubespray_nfs_provisioner.extra_chart_values  | default('') }}"
 
 ingress_nginx:
   namespace: "{{ kubespray_ingress_nginx.namespace | default('ingress-nginx') }}"
-  chart_version: "{{ kubespray_ingress_nginx_controller.chart_version }}"
+  chart_version: "{{ kubespray_ingress_nginx.chart_version | default(kubespray_ingress_nginx_controller.chart_version) }}"
   chart_repo_url: "{{ kubespray_ingress_nginx.chart_repo_url | default('https://kubernetes.github.io/ingress-nginx') }}"
   chart_ref: "{{ kubespray_ingress_nginx.chart_ref | default('ingress-nginx') }}"
   release_name: "{{ kubespray_ingress_nginx.release_name | default('ingress-nginx') }}"
+  chart_values: "{{ kubespray_ingress_nginx.chart_values | default({}) }}"
 
 # Lets encrypt
 acme_cluster_issuer:


### PR DESCRIPTION
- Remove metallb as default cluster load balancer.
- Add configuration to specify values for ingress-nginx and nfs-provisioner helm charts.
- Move remaining `kubespray_ingress_nginx_controller` to `kubespray_ingress_nginx`.
- Update README.